### PR TITLE
OffensiveCon 2023 moved to May!

### DIFF
--- a/Conferences
+++ b/Conferences
@@ -20,7 +20,6 @@ euskalhack
 ## February
 
 * Hack in Paris HIP21 - February 15th-19th, 2021-02-15 - 2021-02-19
-* offensivecon, 2022-02-04 - 2022-02-05, Berlin/Germany, https://www.offensivecon.org
 * disobey - 2021-02-19 - 2021-02-20, Helsinki/Finland, https://disobey.fi
 
 
@@ -36,6 +35,7 @@ euskalhack
 
 ## May
 * North Sec - 18-20.5.2018, https://nsec.io
+* OffensiveCon, 2023-05-19 - 2023-05-20, Berlin/Germany, https://www.offensivecon.org
 * LocoMocoSec - 2020-05-26 - 2020-05-29 Maui/Hawaii/USA, https://locomocosec.com/
 
 ## June


### PR DESCRIPTION
OffensiveCon announced a new date for 2023 on twitter